### PR TITLE
Support for BMC chassis identification

### DIFF
--- a/lib/project_razor/power_control/bmc.rb
+++ b/lib/project_razor/power_control/bmc.rb
@@ -102,13 +102,16 @@ module ProjectRazor
             return @_ipmi.bmc_guid(@ip, username, password)
           when "chassis_status"
             return @_ipmi.chassis_status(@ip, username, password)
+          when "chassis_identify"
+            return @_ipmi.chassis_identify(@ip, username, password)
           when "lan_print"
             return @_ipmi.lan_print(@ip, username, password)
           when "fru_print"
             return @_ipmi.fru_print(@ip, username, password)
           else
             return [false, "Unrecognized query command #{cmd}; acceptable values are power_status," +
-                " bmc_info, bmc_getenables, bmc_guid, chassis_status, lan_print or fru_print"]
+                " bmc_info, bmc_getenables, bmc_guid, chassis_status, chassis_identify," +
+                " lan_print or fru_print"]
         end
       end
 

--- a/lib/project_razor/power_control/ipmi_controller.rb
+++ b/lib/project_razor/power_control/ipmi_controller.rb
@@ -107,6 +107,28 @@ module ProjectRazor
         [true, chassis_hash]
       end
 
+      # A wrapper method for the ipmitool's 'chassis identify' command that can be used to
+      # switch on identification light on machine's chassis for visual identification.
+      #
+      # @param (see #power_status)
+      # @return [Array<Boolean, String>] an array containing a Boolean indicating whether or not the
+      #     'chassis identify' command succeeded and a String containing results of that command
+      def chassis_identify(host_ip, username, passwd)
+        command_failed, identify_output = run_ipmi_command(host_ip, username, passwd, 'chassis', 'identify')
+        if command_failed
+          return [false, identify_output]
+        end
+
+        # e.g.: "Chassis identify interval: default (15 seconds)"
+        identify_output = identify_output.split("\n")
+        identify_interval = /:\s*(off|indefinite|(default \()?\d+ seconds\)?)/.match(identify_output[0])[1]
+        if not identify_output.nil?
+          return [true, identify_interval]
+        end
+
+        return [false, identify_output]
+      end
+
       # A wrapper method for the ipmitool's 'lan print' command that can be used to obtain the
       # 'lan print' information for the node with a specified IP address (as a Hash map).
       #

--- a/lib/project_razor/slice/bmc.rb
+++ b/lib/project_razor/slice/bmc.rb
@@ -62,10 +62,10 @@ module ProjectRazor
         puts "\trazor bmc [get] (UUID) [--query,-q (IPMI_QUERY)]  " + "Display info for a BMC".yellow
         puts "\trazor bmc register (options...)                   " + "Registers a new BMC".yellow
         puts "\trazor bmc update (UUID) --power-state,-p (STATE)  " + "Set power state using BMC".yellow
-        puts "  Note; the IPMI_QUERY value passed via the --query flag be one of (info, guid,".red
-        puts "        enables, fru_print, lan_print, chassis_status, or power_status), while".red
-        puts "        the STATE passed via the --power-state flag can be one of (on, off,".red
-        puts "        cycle, or reset)".red
+        puts "  Note: the IPMI_QUERY value passed via the --query flag be one of (info,".red
+        puts "        guid, enables, fru_print, lan_print, chassis_status, identify or".red
+        puts "        power_status), while the STATE passed via the --power-state flag can".red
+        puts "        be one of (on, off, cycle, or reset)".red
       end
 
       # This function is used to print out an array of all of the Bmc nodes in a tabular form
@@ -385,6 +385,7 @@ module ProjectRazor
       # get, enables => bmc_getenables
       # get, guid => bmc_guid
       # get, chassis_status => chassis_status
+      # get, identify => chassis_identify
       # lan, print => lan_print
       # fru, print => fru_print
       #
@@ -404,6 +405,8 @@ module ProjectRazor
             return "bmc_guid"
           when "get, chassis_status"
             return "chassis_status"
+          when "get, identify"
+            return "chassis_identify"
           when "lan, print"
             return "lan_print"
           when "fru, print"

--- a/spec/ipmi_controller/ipmitool-mock-files/chassis-identify.out
+++ b/spec/ipmi_controller/ipmitool-mock-files/chassis-identify.out
@@ -1,0 +1,1 @@
+Chassis identify interval: default (15 seconds)

--- a/spec/ipmi_controller/rz_ipmi_controller_spec.rb
+++ b/spec/ipmi_controller/rz_ipmi_controller_spec.rb
@@ -66,6 +66,14 @@ describe ProjectRazor::PowerControl::IpmiController do
     @ipmi.chassis_status(@ipmi_hostname, @ipmi_username, @ipmi_password)
   end
 
+  def test_ipmi_chassis_identify_mock
+    filename = @mock_data_dir + File::SEPARATOR + 'chassis-identify.out'
+    @ipmi.expects(:run_ipmi_command).
+        with(@ipmi_hostname, @ipmi_username, @ipmi_password, 'chassis', 'identify').
+        returns([false, File.read(filename)])
+    @ipmi.chassis_identify(@ipmi_hostname, @ipmi_username, @ipmi_password)
+  end
+
   def test_ipmi_lan_print_mock
     filename = @mock_data_dir + File::SEPARATOR + 'lan-print.out'
     @ipmi.expects(:run_ipmi_command).
@@ -155,6 +163,10 @@ describe ProjectRazor::PowerControl::IpmiController do
       yaml_filename = @mock_data_dir + File::SEPARATOR + 'chassis-status.yaml'
       test_hash = YAML::load(File.open(yaml_filename))
       test_ipmi_chassis_status_mock.should == [true, test_hash]
+    end
+
+    it "should switch on identification light on chassis (using the IpmiController)" do
+      test_ipmi_chassis_identify_mock.should == [true, 'default (15 seconds)']
     end
 
     it "should return the impitool lan print as a hash (using the IpmiController)" do


### PR DESCRIPTION
This patch adds support for ipmitool chassis identify command via bmc slice (-q identify). This command is used to switch on lights on machine chassis for visual identification. Thought this could be useful, tests are passing for me.
