### PR TITLE
Added Debian-based package installation to the puppet agent install to avoid dual facter installation by both gem and apt-get

### DIFF
--- a/lib/project_razor/broker/puppet/agent_install.erb
+++ b/lib/project_razor/broker/puppet/agent_install.erb
@@ -4,8 +4,12 @@ set -u
 set -e
 
 function install_puppet() {
-    gem install puppet --no-ri --no-rdoc <%= "--version #{@options[:version]}" if @options[:version] && !@options[:version].empty? %>
-    puppet master --mkusers
+    if [ -f /etc/debian_version ] ; then
+        apt-get -y install puppet
+    else
+        gem install puppet --no-ri --no-rdoc <%= "--version #{@options[:version]}" if @options[:version] && !@options[:version].empty? %>
+        puppet master --mkusers
+    fi
 }
 
 function configure_puppet() {


### PR DESCRIPTION
This is to fix the conflict found in issue https://github.com/puppetlabs/Razor/issues/435, it verifies that it's a Debian based distro before running "apt-get -y install puppet", and if it's not a Debian-based distro it will install normally via gem.
