### PR TITLE
Use node_ip_address, not non-existent node_ip, in the Xenserver IP Pool model template

### DIFF
--- a/lib/project_razor/model/xenserver.rb
+++ b/lib/project_razor/model/xenserver.rb
@@ -105,7 +105,7 @@ module ProjectRazor
       
       def broker_agent_handoff
         logger.debug "Broker agent called for: #{@broker.name}"
-        if @node_ip
+        if @node_ip_address
           options = {
             :username  => "root",
             :password  => @root_password,

--- a/lib/project_razor/model/xenserver.rb
+++ b/lib/project_razor/model/xenserver.rb
@@ -105,13 +105,13 @@ module ProjectRazor
       
       def broker_agent_handoff
         logger.debug "Broker agent called for: #{@broker.name}"
-        if @node_ip_address
+        if node_ip_address
           options = {
             :username  => "root",
             :password  => @root_password,
             :metadata  => node_metadata,
             :uuid  => @node.uuid,
-            :ipaddress => @node_ip_address,
+            :ipaddress => node_ip_address,
           }
           @current_state = @broker.agent_hand_off(options)
         else


### PR DESCRIPTION
The broker_agent_handoff method tests @node_ip and accesses @node_ip_address, but should test and access the method node_ip_address. See issue #486.
