### PR TITLE
Fix filtered queries on array and fixnum values

### DIFF
--- a/lib/project_razor/data.rb
+++ b/lib/project_razor/data.rb
@@ -218,14 +218,25 @@ module ProjectRazor
               # If the filter_hash[filter_key] value is a String and it starts with 'regex:'
               # then use a regular expression for comparison; else compare as literals
               if filter_hash[filter_key].class == String && filter_hash[filter_key].start_with?('regex:')
-                regex_key = filter_hash[filter_key].sub(/^regex:/,"")
-                if Regexp.new(regex_key).match(object_hash[filter_key]) == nil
-                  logger.debug "no match - regex"
+                expr = Regexp.new(filter_hash[filter_key].sub(/^regex:/,""))
+              else
+                expr = filter_hash[filter_key]
+              end
+              case object_hash[filter_key]
+              when Array
+                unless object_hash[filter_key].index{|element| expr === element}
+                  logger.debug "no match - Array"
+                  return false
+                end
+              when Fixnum
+                unless expr === object_hash[filter_key].to_s
+                  logger.debug "no match - Fixnum"
                   return false
                 end
               else
-                if filter_hash[filter_key] != object_hash[filter_key]
-                  logger.debug "no match - literal"
+                unless expr === object_hash[filter_key]
+                  logger.debug "no match - String or Boolean"
+                  logger.debug "#{expr.class} : #{object_hash[filter_key].class}"
                   return false
                 end
               end

--- a/lib/project_razor/data.rb
+++ b/lib/project_razor/data.rb
@@ -240,7 +240,7 @@ module ProjectRazor
                 end
               else
                 unless expr === object_hash[filter_key]
-                  logger.debug "no match - String
+                  logger.debug "no match - String"
                   logger.debug "#{expr.class} : #{object_hash[filter_key].class}"
                   return false
                 end

--- a/lib/project_razor/data.rb
+++ b/lib/project_razor/data.rb
@@ -233,9 +233,14 @@ module ProjectRazor
                   logger.debug "no match - Fixnum"
                   return false
                 end
+              when FalseClass, TrueClass
+                unless (expr === 'true') === object_hash[filter_key]
+                  logger.debug "no match - Boolean"
+                  return false
+                end
               else
                 unless expr === object_hash[filter_key]
-                  logger.debug "no match - String or Boolean"
+                  logger.debug "no match - String
                   logger.debug "#{expr.class} : #{object_hash[filter_key].class}"
                   return false
                 end

--- a/lib/project_razor/data.rb
+++ b/lib/project_razor/data.rb
@@ -234,7 +234,7 @@ module ProjectRazor
                   return false
                 end
               when FalseClass, TrueClass
-                unless (expr === 'true') === object_hash[filter_key]
+                unless (expr === 'true') == object_hash[filter_key]
                   logger.debug "no match - Boolean"
                   return false
                 end

--- a/lib/project_razor/slice.rb
+++ b/lib/project_razor/slice.rb
@@ -532,12 +532,7 @@ class ProjectRazor::Slice < ProjectRazor::Object
         begin
           # Render our JSON to a Hash
           filter_hash = JSON.parse(@filter_json_string)
-          # if any of the Hash values are "true" or "false", convert to equivalent
-          # Boolean values (true and false, respectively)
-          filter_hash.each { |key, val|
-            (filter_hash[key] = true; next) if val == "true"
-            filter_hash[key] = false if val == "false"
-          }
+          logger.debug "filter_hash: #{filter_hash.inspect}"
           return return_objects_using_filter(collection, filter_hash)
         rescue StandardError => e
           # We caught an error / likely JSON. We return the error text as a Slice error.


### PR DESCRIPTION
_Summary of changes_
- Fix both literal and regex filtered queries against Array and Fixnum values in the object hash.
- Unmuddle the contract between Slice#get_object and Data#check_filter_vs_hash. For booleans, get_object was converting the filter strings 'true' and 'false', but did nothing about other types. Let check_filter_vs_hash do the type handling, it knows what the types should be from the object hash and needs to check for Array types anyway.
- Ensure filtered queries against strings and booleans work as before.
- Ensure .../slice?number=alpha is not a match when the object value is 0.

_Assumptions on searched values_
- Element values for Arrays like 'hw_id' and 'tags' are always Strings.
- Numbers are always Fixnums

See issue #489 

Mike
