### PR TITLE
Add an ext_path configuration option to load external custom code.

### DIFF
--- a/lib/project_razor.rb
+++ b/lib/project_razor.rb
@@ -60,6 +60,11 @@ module ProjectRazor
   end
 end
 
+if File.exists?(File.join(ProjectRazor.config.ext_path, "ext.rb"))
+  $:.unshift(ProjectRazor.config.ext_path)
+  require 'ext'
+end
+
 class ::Object
   # Returns hash of classes that are children of
   # the namespace that called the method.

--- a/lib/project_razor/config/server.rb
+++ b/lib/project_razor/config/server.rb
@@ -45,6 +45,7 @@ module ProjectRazor
       attr_accessor :mk_gemlist_uri
 
       attr_accessor :image_svc_path
+      attr_accessor :ext_path
 
       attr_accessor :register_timeout
       attr_accessor :force_mk_uuid
@@ -158,6 +159,7 @@ module ProjectRazor
           'mk_gemlist_uri'           => "http://localhost:2158/gem-mirror/gems/gem.list",
 
           'image_svc_path'           => $img_svc_path,
+          'ext_path'                 => File.join($razor_root, "..", "razor_ext"),
 
           'register_timeout'         => 120,
           'force_mk_uuid'            => "",


### PR DESCRIPTION
This provides an extension point to load in customized Razor models,
kickstart templates, additional persistence backends, etc.

The `ext_path` directory defaults to a path beside the directory
containing Razor's lib/ directory. For example, if Razor is installed
into `/opt/razor`, the `ext_path` directory defaults to
`/opt/razor_ext`.

The extension mechanism will look for an `ext.rb` file in the root of
the `ext_path` directory and require it if it exists. It is up to
extension authors to add further require statements and initialization
logic in this file. Note that the `ext_path` will be added to Razor's
Ruby LOAD_PATH, so a file in the `ext_path` directory called
`acorp/model/acorp_centos_6.rb` can be required in `ext.rb` with:

```
require 'acorp/model/acorp_centos_6'
```
