### PR TITLE
Exchange `echo` lines for HEREDOC in Debian/Ubuntu/Redhat models

### DIFF
--- a/lib/project_razor/model/debian/wheezy/os_complete.erb
+++ b/lib/project_razor/model/debian/wheezy/os_complete.erb
@@ -1,7 +1,9 @@
 #!/bin/bash
-echo Razor policy successfully applied > /tmp/razor_complete.log
-echo Model <%= @label %> - <%= @description %> >> /tmp/razor_complete.log
-echo Image UUID <%= @image_uuid %> >> /tmp/razor_complete.log
-echo Node UUID: <%= @node.uuid %> >> /tmp/razor_complete.log
+cat > /tmp/razor_complete.log << EOF
+Razor policy successfully applied 
+Model <%= @label %> - <%= @description %>
+Image UUID <%= @image_uuid %>
+Node UUID: <%= @node.uuid %>
+EOF
 
 sed -i '/razor_postinstall/d' /etc/rc.local

--- a/lib/project_razor/model/redhat/6/os_complete.erb
+++ b/lib/project_razor/model/redhat/6/os_complete.erb
@@ -1,7 +1,9 @@
 #!/bin/bash
-echo Razor policy successfully applied > /tmp/razor_complete.log
-echo Model <%= @label %> - <%= @description %> >> /tmp/razor_complete.log
-echo Image UUID <%= @image_uuid %> >> /tmp/razor_complete.log
-echo Node UUID: <%= @node.uuid %> >> /tmp/razor_complete.log
+cat > /tmp/razor_complete.log << EOF
+Razor policy successfully applied 
+Model <%= @label %> - <%= @description %>
+Image UUID <%= @image_uuid %>
+Node UUID: <%= @node.uuid %>
+EOF
 
 sed -i --follow-symlinks '/razor_postinstall/d' /etc/rc.local

--- a/lib/project_razor/model/ubuntu/oneiric/os_complete.erb
+++ b/lib/project_razor/model/ubuntu/oneiric/os_complete.erb
@@ -1,7 +1,10 @@
 #!/bin/bash
-echo Razor policy successfully applied > /tmp/razor_complete.log
-echo Model <%= @label %> - <%= @description %> >> /tmp/razor_complete.log
-echo Image UUID <%= @image_uuid %> >> /tmp/razor_complete.log
-echo Node UUID: <%= @node.uuid %> >> /tmp/razor_complete.log
+#!/bin/bash
+cat > /tmp/razor_complete.log << EOF
+Razor policy successfully applied 
+Model <%= @label %> - <%= @description %>
+Image UUID <%= @image_uuid %>
+Node UUID: <%= @node.uuid %>
+EOF
 
 sed -i '/razor_postinstall/d' /etc/rc.local

--- a/lib/project_razor/model/ubuntu/precise/os_complete.erb
+++ b/lib/project_razor/model/ubuntu/precise/os_complete.erb
@@ -1,7 +1,9 @@
 #!/bin/bash
-echo Razor policy successfully applied > /tmp/razor_complete.log
-echo Model <%= @label %> - <%= @description %> >> /tmp/razor_complete.log
-echo Image UUID <%= @image_uuid %> >> /tmp/razor_complete.log
-echo Node UUID: <%= @node.uuid %> >> /tmp/razor_complete.log
+cat > /tmp/razor_complete.log << EOF
+Razor policy successfully applied 
+Model <%= @label %> - <%= @description %>
+Image UUID <%= @image_uuid %>
+Node UUID: <%= @node.uuid %>
+EOF
 
 sed -i '/razor_postinstall/d' /etc/rc.local

--- a/lib/project_razor/model/ubuntu/precise_ip_pool/os_complete.erb
+++ b/lib/project_razor/model/ubuntu/precise_ip_pool/os_complete.erb
@@ -1,7 +1,9 @@
 #!/bin/bash
-echo Razor policy successfully applied > /tmp/razor_complete.log
-echo Model <%= @label %> - <%= @description %> >> /tmp/razor_complete.log
-echo Image UUID <%= @image_uuid %> >> /tmp/razor_complete.log
-echo Node UUID: <%= @node.uuid %> >> /tmp/razor_complete.log
+cat > /tmp/razor_complete.log << EOF
+Razor policy successfully applied 
+Model <%= @label %> - <%= @description %>
+Image UUID <%= @image_uuid %>
+Node UUID: <%= @node.uuid %>
+EOF
 
 sed -i '/razor_postinstall/d' /etc/rc.local


### PR DESCRIPTION
...thereby fixing bash syntax errors in the created `rc.local` if the
model contains parentheses (such as ubuntu/precise_ip_pool).

(Note that this no longer allows for using, say, "$(date)" as model description...)